### PR TITLE
Set caching to 0

### DIFF
--- a/src/main/java/com/edhollingsworth/geotrak/gtserver/api/GeoTrakResolver.java
+++ b/src/main/java/com/edhollingsworth/geotrak/gtserver/api/GeoTrakResolver.java
@@ -118,7 +118,7 @@ public class GeoTrakResolver implements InitializingBean {
 	 * constructor.
 	 */
 	private void initializePublisher() {
-		initializePublisher(10); // send default value
+		initializePublisher(0); // send default value
 	}
 	private void initializePublisher(int cacheSize) {
 		// Register an anonymous GeoTrakListener implementation


### PR DESCRIPTION
Zero out the default cache size to stop reload of last 10 messages every time Kafka connection is re-established.